### PR TITLE
Display path of file where error occured

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -65,9 +65,9 @@ func genAbsPath(path string) string {
 	return path
 }
 
-func checkError(err error) {
+func checkFileError(trimPath,file string, err error) {
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(strings.TrimPrefix(file,trimPath + "/") + ": " + err.Error())
 	}
 }
 
@@ -204,7 +204,7 @@ func Generate(source, dest, pkgName string, extensions []string) {
 	sourceDir := source
 
 	srcStat, err := os.Stat(source)
-	checkError(err)
+	checkFileError("",source,err)
 
 	fmt.Println("Parsing...")
 	if srcStat.IsDir() {
@@ -276,14 +276,14 @@ func Generate(source, dest, pkgName string, extensions []string) {
 			definition := definitions[0].chunk.String()
 
 			funcDecl, err := parseDefinition(definition)
-			checkError(err)
+			checkFileError(sourceDir,source,err)
 
 			buffer.WriteString(definition)
 			buffer.WriteString(`{
 			`)
 
 			paramName, paramType, err := parseParams(funcDecl)
-			checkError(err)
+			checkFileError(sourceDir,source,err)
 
 			if paramType == TypeIOWriter {
 				bufName := "_buffer"


### PR DESCRIPTION
Currently when error occurs hero returns something like

    2020/01/09 02:22:03 2:62: expected ';', found 'EOF' (and 1 more errors)

this patch changes it to add relative path to the error message:

    2020/01/09 02:22:38 shared/subcomment.html: 2:62: expected ';', found 'EOF' (and 1 more errors)

